### PR TITLE
fix: css background

### DIFF
--- a/sidebery/dark_sidebery_styles.css
+++ b/sidebery/dark_sidebery_styles.css
@@ -13,6 +13,11 @@
 	--warn: #8c4351 !important;
 }
 
+#root.root {
+		--toolbar-bg: var(--bg) !important;
+		--frame-bg: var(--bg) !important;
+}
+
 #root .Tab {
 	--tabs-indent: 7px;
 }

--- a/sidebery/light_sidebery_styles.css
+++ b/sidebery/light_sidebery_styles.css
@@ -7,6 +7,11 @@
 	--warn: #fca5a5 !important;
 }
 
+#root.root {
+		--toolbar-bg: var(--bg) !important;
+		--frame-bg: var(--bg) !important;
+}
+
 #root .Tab {
 	--tabs-indent: 7px;
 }

--- a/sidebery/sidebery_styles.css
+++ b/sidebery/sidebery_styles.css
@@ -8,6 +8,11 @@
         --warn: #fca5a5 !important;
     }
 
+	#root.root {
+			--toolbar-bg: var(--bg) !important;
+			--frame-bg: var(--bg) !important;
+	}
+
     #root .Tab {
         --tabs-indent: 7px;
     }
@@ -172,6 +177,11 @@
         --panel-btn: #f2f2f2 !important;
         --warn: #8c4351 !important;
     }
+
+	#root.root {
+			--toolbar-bg: var(--bg) !important;
+			--frame-bg: var(--bg) !important;
+	}
 
     #root .Tab {
         --tabs-indent: 7px;


### PR DESCRIPTION
版本：linux 
firefox 132.0
Sidebery 5.2.0

Sidebery的背景色并不能被正确修改，我在css中添加了
```
#root.root {
	--toolbar-bg: var(--bg) !important;
	--frame-bg: var(--bg) !important;
}
```

就正常了


![Screenshot_2024-10-31-23-03-07.png](https://s2.loli.net/2024/10/31/wCpbi54vdesySBJ.png)

![Screenshot_2024-10-31-23-03-34.png](https://s2.loli.net/2024/10/31/9QN4zsU6yXpTixh.png)
