### PR TITLE
Fix Linux 地址栏宽度占满

### DIFF
--- a/linux/userChrome.css
+++ b/linux/userChrome.css
@@ -87,8 +87,9 @@
     top: calc(
         (var(--urlbar-toolbar-height) - var(--urlbar-height)) / 2
     ) !important;
-    left: 0 !important;
-    width: 100% !important;
+    /* left: 0 !important; */
+    /* width: 100% !important; */
+    width: calc(--urlbar-width) !important;
 }
 
 #urlbar-container {


### PR DESCRIPTION
https://github.com/christorange/VerticalFox/issues/69 的问题在 Linux 下同样出现，修复同 https://github.com/christorange/VerticalFox/pull/70